### PR TITLE
[Fix] Add dependent destroy for model, catalog in connectors and sync_runs in sync

### DIFF
--- a/app/models/connector.rb
+++ b/app/models/connector.rb
@@ -28,8 +28,8 @@ class Connector < ApplicationRecord
 
   belongs_to :workspace
 
-  has_many :models, dependent: :nullify
-  has_one :catalog, dependent: :nullify
+  has_many :models, dependent: :destroy
+  has_one :catalog, dependent: :destroy
 
   def connector_definition
     @connector_definition ||= connector_client.new.meta_data.with_indifferent_access

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -25,7 +25,7 @@ class Model < ApplicationRecord
   belongs_to :workspace
   belongs_to :connector
 
-  has_many :syncs, dependent: :nullify
+  has_many :syncs, dependent: :destroy
 
   def to_protocol
     Multiwoven::Integrations::Protocol::Model.new(

--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -37,7 +37,7 @@ class Sync < ApplicationRecord
   belongs_to :source, class_name: "Connector"
   belongs_to :destination, class_name: "Connector"
   belongs_to :model
-  has_many :sync_runs, dependent: :nullify
+  has_many :sync_runs, dependent: :destroy
 
   after_initialize :set_defaults, if: :new_record?
   after_save :schedule_sync, if: :schedule_sync?

--- a/spec/models/connector_spec.rb
+++ b/spec/models/connector_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe Connector, type: :model do
 
   context "associations" do
     it { should belong_to(:workspace) }
-    it { should have_many(:models).dependent(:nullify) }
-    it { should have_one(:catalog).dependent(:nullify) }
+    it { should have_many(:models).dependent(:destroy) }
+    it { should have_one(:catalog).dependent(:destroy) }
   end
 
   describe "#to_protocol" do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Model, type: :model do
     it { should validate_presence_of(:connector_id) }
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:query) }
-    it { should have_many(:syncs).dependent(:nullify) }
+    it { should have_many(:syncs).dependent(:destroy) }
   end
 
   describe "#to_protocol" do
@@ -46,6 +46,7 @@ RSpec.describe Model, type: :model do
       expect(protocol_model.query).to eq(model.query)
       expect(protocol_model.query_type).to eq(model.query_type)
       expect(protocol_model.primary_key).to eq(model.primary_key)
+      expect(model).to have_many(:syncs).dependent(:destroy)
     end
   end
 end

--- a/spec/models/sync_spec.rb
+++ b/spec/models/sync_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Sync, type: :model do
   it { should belong_to(:source).class_name("Connector") }
   it { should belong_to(:destination).class_name("Connector") }
   it { should belong_to(:model) }
-  it { should have_many(:sync_runs) }
+  it { should have_many(:sync_runs).dependent(:destroy) }
 
   describe "#to_protocol" do
     let(:streams) do


### PR DESCRIPTION
## Description
[Fix] Add dependent destroy for the model, catalog in connectors and sync_runs in sync

## Related Issue
None

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [ ] Chore
  
## How Has This Been Tested?
Wrote unit test

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
