### PR TITLE
chore: Update integration gem to 0.1.28

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "interactor", "~> 3.0"
 
 gem "ruby-odbc", git: "https://github.com/Multiwoven/ruby-odbc.git"
 
-gem "multiwoven-integrations", "~> 0.1.27"
+gem "multiwoven-integrations", "~> 0.1.28"
 
 gem "temporal-ruby", github: "coinbase/temporal-ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1839,7 +1839,7 @@ GEM
     msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.4.0)
-    multiwoven-integrations (0.1.27)
+    multiwoven-integrations (0.1.28)
       activesupport
       async-websocket
       dry-schema
@@ -2079,7 +2079,7 @@ DEPENDENCIES
   jbuilder
   jwt
   kaminari
-  multiwoven-integrations (~> 0.1.27)
+  multiwoven-integrations (~> 0.1.28)
   newrelic_rpm
   parallel
   pg (~> 1.1)


### PR DESCRIPTION
## Description
chore: Update multiwoven gem to 0.1.28

## Related Issue
None

## Type of Change
- [ ] Feature
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Documentation update
- [x] Chore
  
## How Has This Been Tested?
None

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
